### PR TITLE
Removed extraneous quote and corrected field name

### DIFF
--- a/apidocs/dev-guide/general-api-info/service-access-endpoints.rst
+++ b/apidocs/dev-guide/general-api-info/service-access-endpoints.rst
@@ -40,6 +40,6 @@ Replace the ``1234`` with your Rackspace Cloud account number.
 
 You can find the complete endpoint URI with your account number appended in the service catalog 
 that is returned in the :ref:`authentication response <review-auth-resp>`. Search the 
-catalog for the service name, ``"rax:database`` . Then copy the URI from the publicURL field 
+catalog for the service type, ``rax:database`` . Then copy the URI from the publicURL field 
 for the region you want to use.
 


### PR DESCRIPTION
In paragraph below table,  the string to search for is "service type", not "service name" .   Needs to be corrected in Orchestration and other docs as well.