### PR TITLE
Change link to submit an issue

### DIFF
--- a/api-docs/_deconst.json
+++ b/api-docs/_deconst.json
@@ -3,6 +3,6 @@
   "githubUrl": "https://github.com/rackerlabs/docs-cloud-databases/",
   "githubBranch": "master",
   "meta": {
-    "preferGithubIssues": false
+    "preferGithubIssues": true
   }
 }


### PR DESCRIPTION
Singlehtml template doesn't support opening to the current topic for editing.
Change all API docs to use submit issue link instead of Edit on GitHub.