### PR TITLE
Add link to new CA cert in using-ssl.rst

### DIFF
--- a/api-docs/general-api-info/using-ssl.rst
+++ b/api-docs/general-api-info/using-ssl.rst
@@ -13,7 +13,7 @@ Cloud Databases installs a certificate on the database instance at the time of p
 
 To use SSL, perform the following steps:
 
--  For encrypting connections using SSL, download the certificate:
+-  For encrypting connections using SSL, download the certificate from one of the following URLs:
 
    - For servers created before March 1, 2016: http://ssl.rackspaceclouddb.com/ca-cert.pem.
    - For servers created on or after March 1, 2016: http://ssl.rackspaceclouddb.com/rackspace-ca-2016.pem.

--- a/api-docs/general-api-info/using-ssl.rst
+++ b/api-docs/general-api-info/using-ssl.rst
@@ -13,13 +13,16 @@ Cloud Databases installs a certificate on the database instance at the time of p
 
 To use SSL, perform the following steps:
 
--  For encrypting connections using SSL, download the certificate from http://ssl.rackspaceclouddb.com/ca-cert.pem.
+-  For encrypting connections using SSL, download the certificate:
 
--  To use SSL with the default MySQL command line, pass the SSL certificate to the client at startup:
+   - For servers created before March 1, 2016: http://ssl.rackspaceclouddb.com/ca-cert.pem.
+   - For servers created on or after March 1, 2016: http://ssl.rackspaceclouddb.com/rackspace-ca-2016.pem.
 
-   .. code::  
+-  To use SSL with the default MySQL command line, pass the downloaded SSL certificate to the client at startup:
 
-       mysql —ssl-ca=/path/to/ca-cert.pem
+   .. code::
+
+       mysql —ssl-ca=/path/to/rackspace-ca-2016.pem
 
    The official MySQL docs for using SSL are located at http://dev.mysql.com/doc/refman/5.6/en/using-ssl-connections.html.
 


### PR DESCRIPTION
All instances created after March 1, 2016 will use a new Ssl certificate. This update will point customers to the right CA cert

This one is fairly urgent, so would like this pushed through quickly if possible