### PR TITLE
Fixing broken links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 This repository contains the source files that generate the following Cloud databases API documentation: 
 
-* [Getting Started Guide](https://developer.rackspace.com/docs/cloud-databases/v2/developer-guide/#document-getting-started)
-* [Developer Guide](https://developer.rackspace.com/docs/cloud-databases/v2/developer-guide/#document-developer-guide)
-* [API Reference](https://developer.rackspace.com/docs/cloud-databases/v2/developer-guide/#api-reference)
+* [Getting Started Guide](https://developer.rackspace.com/docs/cloud-databases/v1/developer-guide/#document-getting-started)
+* [Developer Guide](https://developer.rackspace.com/docs/cloud-databases/v1/developer-guide/#document-developer-guide)
+* [API Reference](https://developer.rackspace.com/docs/cloud-databases/v1/developer-guide/#api-reference)
 
 When you commit changes to the master branch of this repository, the 
 [Strider CI/CD build job](https://build.developer.rackspace.com/rackerlabs/docs-cloud-databases/) 


### PR DESCRIPTION
The links in the README were broken and pointed to v2 Cloud Database docs. Right now all of the Cloud DB docs are still V1